### PR TITLE
fix combo syntax

### DIFF
--- a/veronicaanglesplit/keymaps/default/keymap.c
+++ b/veronicaanglesplit/keymaps/default/keymap.c
@@ -53,6 +53,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 const uint16_t PROGMEM combo_del[] = {KC_Y, KC_H, COMBO_END};
 
 combo_t key_combos[COMBO_COUNT] = {
-  [COMBO_DEL] = COMBO(combo_del,KC_DEL)
+  COMBO(combo_del,KC_DEL)
 };
 #endif

--- a/veronicaanglesplit/keymaps/default/keymap.c
+++ b/veronicaanglesplit/keymaps/default/keymap.c
@@ -16,10 +16,6 @@ qk_tap_dance_action_t tap_dance_actions[] = {
 };
 #endif
 
-enum combo_events {
-  COMBO_DEL
-};
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT(
         KC_Q,        KC_W,    KC_E,    KC_R,    KC_T,               KC_Y,   KC_U,    KC_I,    KC_O,    KC_P,


### PR DESCRIPTION
Combo should work now by matching the syntax to the example in QMK docs: https://qmk.github.io/qmk_docs_devel/#/feature_combo?id=combos